### PR TITLE
Simpler algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,27 +45,25 @@ import Auction "mo:auction";
 To play around with the matching algorithm you can use the following template and change the bids and asks:
 
 ```motoko
-//@package auction research-ag/auction/tree/main/src
-import Principal "mo:base/Principal";
-import Iter "mo:base/Iter";
-
-import { clearAuction } "mo:auction";
+//@package auction research-ag/auction/main/src
+import Float "mo:base/Float";
+import Auction "mo:auction";
 
 let asks = [
-  (50.0, 10_000),
-  (60.0, 10_000),
-  (70.0, 10_000),
+  (50.0, 100),
+  (60.0, 100),
+  (70.0, 100),
 ];
 let bids = [
-  (70.0, 10_000),
-  (60.0, 10_000),
-  (50.0, 10_000),
+  (70.0, 100),
+  (60.0, 100),
+  (50.0, 100),
 ];
 
-clearAuction(asks.vals(), bids.vals());
+Auction.clear(asks.vals(), bids.vals(), Float.less);
 ```
 
-Edit and run this template on: [embed.motoko.org](https://embed.motoko.org/motoko/g/3xqAn1QTGMqrD5wvpZFpDsNsBPffM956V3tho5ZX2hx6RQAU8YiVojYUGtTci8YNi6dFaqqK9yjWYZKq3CgCXxg8fBRpQ37apEmKwXBYHJ8SxxkVraiEYBV79opMUcG6UKhCHZojdyzKcW7kiHRtSKctw41J5QATxbDsUCFQowb52XoecLRss6kqKQV74icWtW6D9CLcoC5pRqvNpn7M4n7Fsb3rYoLBqzmLRMq8LZqDAfGyrWekh?lines=19)
+Edit and run this template on: [embed.motoko.org](https://embed.motoko.org/motoko/g/QzWqprifHe2NQ7xGqbqnBoy8hqNZsnc3b2jLuzivSPwtbwac47MB7fAWU3LUs3zR3JNA4V2EXBACwEErn1w2dUb9KruaTj5KU52QnDA3PoL3bJMe4UuRdn8VyKpeVyfJizz4TY355hkTTKJZ7xkoYDuNTnVC4w7UWgJ2mzQCL4dXGGKiG3J1J4WxE7CvUx3ja7pXnaHo2Dhyg6Pjg1vhWLg7x4hSgDjd?lines=17)
 
 We will analyze a few concrete examples.
 
@@ -73,41 +71,41 @@ We will analyze a few concrete examples.
 
 ```motoko
 let asks = [
-  (50.0, 10_000),
-  (60.0, 10_000),
-  (70.0, 10_000),
+  (50.0, 100),
+  (60.0, 100),
+  (70.0, 100),
 ];
 let bids = [
-  (70.0, 10_000),
-  (60.0, 10_000),
-  (50.0, 10_000),
+  (70.0, 100),
+  (60.0, 100),
+  (50.0, 100),
 ];
 
-let (price, volume) = matchOrders(asks.vals(), bids.vals());
-// => (60.0, 20_000)
+Auction.clear(asks.vals(), bids.vals(), Float.less);
+// => ?(60.0, 200)
 ```
 
-We see three asks and bids that could individually be matched to each other at three different prices for a total volume of 30,000.
-But at a single price the highest volume possible is 20,000 and it is reached at the price of 60.
+We see three asks and bids that could individually be matched to each other at three different prices for a total volume of 300.
+But at a single price the highest volume possible is 200 and it is reached at the price of 60.
 
 #### Example 2
 
 ```motoko
 let asks = [
-  (0.0, 10_000),
+  (0.0, 100),
 ];
 let bids = [
-  (100.0, 2_000),
-  (90.0, 2_000),
-  (80.0, 2_000),
-  (70.0, 2_000),
-  (60.0, 2_000), // volume of 10_000 reached here
-  (50.0, 2_000),
-  (40.0, 2_000),
+  (100.0, 20),
+  (90.0, 20),
+  (80.0, 20),
+  (70.0, 20),
+  (60.0, 20), // volume of 100 reached here
+  (50.0, 20),
+  (40.0, 20),
 ];
+Auction.clear(asks.vals(), bids.vals(), Float.less);
 
-let (price, volume) = matchOrders(asks.vals(), bids.vals());
-// => (60.0, 10_000)
+// => ?(60.0, 100)
 ```
 
 Here, a single market sell order (ask)
@@ -118,18 +116,18 @@ The price is the highest price needed to fully match the sell order.
 
 ```motoko
 let asks = [
-  (50.0, 10_000),
-  (60.0, 10_000),
-  (70.0, 10_000),
+  (50.0, 100),
+  (60.0, 100),
+  (70.0, 100),
 ];
 let bids = [
-  (40.0, 10_000),
-  (30.0, 10_000),
-  (20.0, 10_000),
+  (40.0, 100),
+  (30.0, 100),
+  (20.0, 100),
 ];
+Auction.clear(asks.vals(), bids.vals(), Float.less);
 
-let (price, volume) = matchOrders(asks.vals(), bids.vals());
-// => (0.0, 0)
+// => null
 ```
 
 Here, 
@@ -140,23 +138,23 @@ hence no volume can be exchanged.
 
 ```motoko
 let asks = [
-  (50.0, 5_000),
-  (60.0, 3_000),
-  (70.0, 10_000),
+  (50.0, 50),
+  (60.0, 30),
+  (70.0, 100),
 ];
 let bids = [
-  (70.0, 10_000),
-  (60.0, 2_000),
+  (70.0, 100),
+  (60.0, 20),
 ];
 
-let (price, volume) = matchOrders(asks.vals(), bids.vals());
-// => (70.0, 10_000)
+Auction.clear(asks.vals(), bids.vals(), Float.less);
+// => ?(70.0, 100)
 ```
 
 Here, we see the partial fulfilment an order.
-The maximum volume is 10,000 which is reached at the price of 70.0.
-The total ask volume at his price is 18,000 and the total bid volume only 10,000.
-Hence the first two ask order get filled and the third ask order get partially filled with 2,000 out of 10,000. 
+The maximum volume is 100 which is reached at the price of 70.0.
+The total ask volume at his price is 180 and the total bid volume only 100.
+Hence the first two ask order get filled and the third ask order get partially filled with 20 out of 100. 
 Note that the price of last ask is used in the price calculation, regardless of how much volume is fulfilled from it.
 
 ### Build & test
@@ -179,10 +177,11 @@ mops bench --replica pocket-ic
 
 ## Copyright
 
-MR Research AG, 2023-24
+MR Research AG, 2024
 ## Authors
 
-Main authors: Andy Gura (AndyGura), Timo Hanke (timohanke)
+Main authors: Timo Hanke (timohanke)  
+Contributors: Andy Gura (AndyGura) 
 ## License
 
 Apache-2.0

--- a/bench/clear-auction.bench.mo
+++ b/bench/clear-auction.bench.mo
@@ -6,17 +6,17 @@ import Nat "mo:base/Nat";
 import Prim "mo:prim";
 import Text "mo:base/Text";
 
-import Clear "../src";
+import Auction "../src";
 
 module {
 
-  type Order = Clear.Order<Float>;
+  type Order = Auction.Order<Float>;
 
   func clearAuction(
     asks : Iter.Iter<Order>,
     bids : Iter.Iter<Order>,
-  ) : ?Clear.priceResult<Float> {
-    Clear.clearAuction<Float>(asks, bids, Float.less);
+  ) : ?Auction.priceResult<Float> {
+    Auction.clearAuction<Float>(asks, bids, Float.less);
   };
 
   public func init() : Bench.Bench {

--- a/bench/clear-auction.bench.mo
+++ b/bench/clear-auction.bench.mo
@@ -1,13 +1,23 @@
 import Array "mo:base/Array";
 import Bench "mo:bench";
+import Float "mo:base/Float";
 import Iter "mo:base/Iter";
 import Nat "mo:base/Nat";
 import Prim "mo:prim";
 import Text "mo:base/Text";
 
-import { clearAuctionFloat } "../src";
+import Clear "../src";
 
 module {
+
+  type Order = Clear.Order<Float>;
+
+  func clearAuction(
+    asks : Iter.Iter<Order>,
+    bids : Iter.Iter<Order>,
+  ) : ?Clear.priceResult<Float> {
+    Clear.clearAuction<Float>(asks, bids, Float.less);
+  };
 
   public func init() : Bench.Bench {
     let bench = Bench.Bench();
@@ -35,7 +45,7 @@ module {
     bench.rows(rows);
     bench.cols(cols);
 
-    let envs = Array.tabulate<(asks : Iter.Iter<(price : Float, volume : Nat)>, bids : Iter.Iter<(price : Float, volume : Nat)>, res : (price : Float, volume : Nat))>(
+    let envs = Array.tabulate<(asks : Iter.Iter<(price : Float, volume : Nat)>, bids : Iter.Iter<(price : Float, volume : Nat)>, res : ?(price : Float, volume : Nat))>(
       rows.size() * cols.size(),
       func(i) {
         let row : Nat = i % rows.size();
@@ -67,8 +77,8 @@ module {
           Array.vals(asks),
           Array.vals(bids),
           switch (nAsks, nBids) {
-            case ((0, _) or (_, 0)) (0.0, 0);
-            case (_) (criticalPrice, dealVolume);
+            case ((0, _) or (_, 0)) null;
+            case (_) ?(criticalPrice, dealVolume);
           },
         );
       },
@@ -80,11 +90,10 @@ module {
         let ?ri = Array.indexOf<Text>(row, rows, Text.equal) else Prim.trap("Cannot determine row: " # row);
         let (asks, bids, expectedResult) = envs[ci * rows.size() + ri];
 
-        let result = clearAuctionFloat(asks, bids);
+        let result = clearAuction(asks, bids); 
 
         // make sure everything worked as expected
-        assert result.0 == expectedResult.0;
-        assert result.1 == expectedResult.1;
+        assert result == expectedResult;
       }
     );
 

--- a/bench/clear-auction.bench.mo
+++ b/bench/clear-auction.bench.mo
@@ -5,7 +5,7 @@ import Nat "mo:base/Nat";
 import Prim "mo:prim";
 import Text "mo:base/Text";
 
-import { clearAuction } "../src";
+import { clearAuctionFloat } "../src";
 
 module {
 
@@ -80,7 +80,7 @@ module {
         let ?ri = Array.indexOf<Text>(row, rows, Text.equal) else Prim.trap("Cannot determine row: " # row);
         let (asks, bids, expectedResult) = envs[ci * rows.size() + ri];
 
-        let result = clearAuction(asks, bids);
+        let result = clearAuctionFloat(asks, bids);
 
         // make sure everything worked as expected
         assert result.0 == expectedResult.0;

--- a/bench/clear-auction.bench.mo
+++ b/bench/clear-auction.bench.mo
@@ -16,7 +16,7 @@ module {
     asks : Iter.Iter<Order>,
     bids : Iter.Iter<Order>,
   ) : ?Auction.priceResult<Float> {
-    Auction.clearAuction<Float>(asks, bids, Float.less);
+    Auction.clear<Float>(asks, bids, Float.less);
   };
 
   public func init() : Bench.Bench {

--- a/mops.toml
+++ b/mops.toml
@@ -7,12 +7,12 @@ keywords = [ "exchange", "tokens", "order matching" ]
 license = "Apache-2.0"
 
 [dependencies]
-base = "0.12.0"
+base = "0.12.1"
 
 [dev-dependencies]
 test = "2.0.0"
 bench = "1.0.0"
 
 [toolchain]
-moc = "0.12.0"
+moc = "0.12.1"
 pocket-ic = "1.0.0"

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -29,8 +29,8 @@ module {
   ///
   /// Suppose we have a single trading pair with base currency X and quote currency Y.
   /// The algorithm requires as input an list of bid order sorted in descending order of price and a list of ask orders sorted in ascending order of price.
-  /// The algorithm will then find the price range at which the maximum volume of orders can be executed.
-  /// It returns that price range and the volume that can be executed at that price.
+  /// The algorithm will then find the price point at which the maximum volume of orders can be executed.
+  /// It returns that price point and the volume that can be executed at that price.
   ///
   /// In a volume maximising auction all participants get their trades executed in one event,
   /// at the same time and at the same price.

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -3,9 +3,11 @@
 /// Copyright: 2023-2024 MR Research AG
 /// Authors: Andy Gura (AndyGura), Timo Hanke (timohanke)
 
+import Debug "mo:base/Debug";
+import Float "mo:base/Float";
+import Int "mo:base/Int";
 import Iter "mo:base/Iter";
 import Nat "mo:base/Nat";
-import Debug "mo:base/Debug";
 
 /// Clearing algorithm for a volume maximising uniform-price auction
 ///
@@ -20,10 +22,9 @@ import Debug "mo:base/Debug";
 module {
 
   /// Orders are specified by a limit price measured in quote currency and a volume measured in base currency.
-  public type Order = (price : Float, volume : Nat);
+  public type Order<X> = (price : X, volume : Nat);
 
-  let noVolume = (0.0, 0);
-  let noVolumeRange = { range = (0.0, 0.0); volume = 0 }; 
+  let noVolumeRange = { range = (0.0, 0.0); volume = 0 };
 
   /// Clearing algorithm for a volume maximising uniform-price auction
   ///
@@ -36,7 +37,7 @@ module {
   /// at the same time and at the same price.
   /// Or, if their orders missed the execution price then they are not executed at all.
   ///
-  /// A bid order and ask order is a pair of price (type Float) and volume (type Nat).
+  /// A bid order and ask order is a pair of price and volume.
   /// The price is denominated in Y and the volume is denominated in X.
   /// The price means the price for the smallest unit of Y and is measured in the smallest unit of X.
   /// The volume is measured in the smallest unit of Y.
@@ -51,26 +52,42 @@ module {
   /// All orders whose volume was accumulated during the walks will be executed.
   /// We say these order were "matched".
   ///
+  /// The price type is generic and is provided as a type parameter.
+  /// For example, it can be Float, Nat or Int.
+  /// The caller has to supply a comparison function `less` for the price type
+  /// and a dummy value of the price type which can be returned as a dummy value when there are no matching orders.
+  /// Since the algorithm uses only the comparison function `less`,
+  /// it has no notion of a "valid price range".
+  /// For price type Float, for example, the algorithm will work fine with negative prices, zero and infinity.
+  ///
+  /// The algorithm accepts all possible Float values as prices including 0, infinity and negative values.
+  /// This is possible because only the relative order of prices matters, not their actual arithmetic value.
+  ///
+  /// The volume type is Nat. 
+  ///
   /// # Parameters:
-  /// - `asks: Iter.Iter<Order>`: An iterator over the ask orders. Must be in ascending (precisely: non-descending) order of price.
-  /// - `bids: Iter.Iter<Order>`: An iterator over the bid orders. Must be in descending (precisely: non-ascending) order of price.
+  /// - `asks: Iter.Iter<Order<X>>`: An iterator over the ask orders. Must be in ascending (precisely: non-descending) order of price.
+  /// - `bids: Iter.Iter<Order<X>>`: An iterator over the bid orders. Must be in descending (precisely: non-ascending) order of price.
+  /// - `less: (X,X) -> Bool`: comparison function 
+  /// - `dummyPrice: X`: an arbitrary value of type X
   ///
   /// # Returns:
   /// - `volume: Nat`: The total matched volume at the determined price.
-  /// - `price: Float`: The determined execution price that maximises volume.
+  /// - `price: X`: The determined execution price that maximises volume.
   ///
   /// The price is determined by the lowest matched ask order.
   /// The returned volume is 0 if and only if no order can be matched.
   /// In this case the price is meaningless but is returned as 0.0.
   ///
-  /// The algorithm accepts all possible Float values as prices including 0, infinity and negative values.
-  /// This is possible because only the relative order of prices matters, not their actual arithmetic value.
   ///
   /// The algorithm accepts orders with volume 0. Such orders have no influence on the return values.
-  public func clearAuction(
-    asks : Iter.Iter<Order>,
-    bids : Iter.Iter<Order>,
-  ) : (price : Float, volume : Nat) {
+  public func clearAuction<X>(
+    asks : Iter.Iter<Order<X>>,
+    bids : Iter.Iter<Order<X>>,
+    less : (X, X) -> Bool,
+    dummyPrice : X,
+  ) : (price : X, volume : Nat) {
+    let noVolume = (dummyPrice, 0);
     let ?first_ask = asks.next() else return noVolume;
     var price = first_ask.0;
     var askVolume = first_ask.1; // (cumulative)
@@ -79,28 +96,49 @@ module {
     // invariant here: askVolume >= bidVolume
     label L loop {
       let ?bid = bids.next() else break L;
-      if (bid.0 < price) break L;
+      if (less(bid.0, price)) break L;
       bidVolume += bid.1;
       while (askVolume < bidVolume) {
         let ?ask = asks.next() else break L;
-        if (ask.0 > bid.0) break L;
+        if (less(bid.0, ask.0)) break L;
         price := ask.0;
         askVolume += ask.1;
       };
     };
 
     let vol = Nat.min(askVolume, bidVolume);
-    if (vol == 0) price := 0.0;
+    if (vol == 0) return noVolume;
     return (price, vol);
   };
 
+  public func clearAuctionFloat(
+    asks : Iter.Iter<Order<Float>>,
+    bids : Iter.Iter<Order<Float>>,
+  ) : (price : Float, volume : Nat) {
+    clearAuction<Float>(asks, bids, Float.less, 0.0);
+  };
+
+  public func clearAuctionNat(
+    asks : Iter.Iter<Order<Nat>>,
+    bids : Iter.Iter<Order<Nat>>,
+  ) : (price : Nat, volume : Nat) {
+    clearAuction<Nat>(asks, bids, Nat.less, 0);
+  };
+
+  public func clearAuctionInt(
+    asks : Iter.Iter<Order<Int>>,
+    bids : Iter.Iter<Order<Int>>,
+  ) : (price : Int, volume : Nat) {
+    clearAuction<Int>(asks, bids, Int.less, 0);
+  };
+ 
 
   /// Clearing algorithm for a volume maximising uniform-price auction
   ///
   /// Compared to `clearAuction` this functions returns the full range of maximum trade volume.
   public func clearAuctionRange(
-    asks : Iter.Iter<Order>,
-    bids : Iter.Iter<Order>,
+    asks : Iter.Iter<Order<Float>>,
+    bids : Iter.Iter<Order<Float>>,
   ) : {
     range : (Float, Float);
     volume : Nat;
@@ -129,7 +167,7 @@ module {
 
     let volume = Nat.min(askVolume, bidVolume);
     if (volume == 0) return noVolumeRange;
-    let range = switch(price_bid) {
+    let range = switch (price_bid) {
       case (?x) (price_ask, x);
       case (null) Debug.trap("should not happen");
     };

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -1,6 +1,6 @@
 /// A module which implements auction functionality
 ///
-/// Copyright: 2023-2024 MR Research AG
+/// Copyright: 2024 MR Research AG
 /// Author: Timo Hanke (timohanke)
 /// Contributors: Andy Gura (AndyGura) 
 
@@ -97,9 +97,10 @@ module {
       let ?bid = bids.next() else break L;
       if (less(bid.0, price)) break L;
       bidVolume += bid.1;
-      while (askVolume < bidVolume) {
+      label W while (askVolume < bidVolume) {
         let ?ask = asks.next() else break L;
         if (less(bid.0, ask.0)) break L;
+        if (ask.1 == 0) continue W; // skip 0 volume asks
         price := ask.0;
         askVolume += ask.1;
       };
@@ -139,9 +140,10 @@ module {
       if (bid.1 == 0) continue L; // skip 0 volume bids
       bidVolume += bid.1;
       if (not askNeeded) bidPrice := ?bid.0; // if askNeeded then do this later below
-      while (askVolume < bidVolume) {
+      label W while (askVolume < bidVolume) {
         let ?ask = asks.next() else break L;
         if (less(bid.0, ask.0)) break L;
+        if (ask.1 == 0) continue W; // skip 0 volume asks
         if (askNeeded) bidPrice := ?bid.0;
         askPrice := ask.0;
         askVolume += ask.1;

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -77,8 +77,7 @@ module {
   ///
   /// The price is determined by the lowest matched ask order.
   /// The returned volume is 0 if and only if no order can be matched.
-  /// In this case the price is meaningless but is returned as 0.0.
-  ///
+  /// In this case the price is meaningless and the provided dummy price is returned.
   ///
   /// The algorithm accepts orders with volume 0. Such orders have no influence on the return values.
   public func clearAuction<X>(

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -83,7 +83,7 @@ module {
   ///
   /// The algorithm accepts orders with volume 0. Such orders have no influence on the return values.
   /// The algorithm also accepts multiple orders in a row with the same price. 
-  public func clearAuction<X>(
+  public func clear<X>(
     asks : Iter.Iter<Order<X>>,
     bids : Iter.Iter<Order<X>>,
     less : (X, X) -> Bool,
@@ -115,7 +115,7 @@ module {
   /// Clearing algorithm for a volume maximising uniform-price auction
   ///
   /// Compared to `clearAuction` this functions returns the full range of maximum trade volume.
-  public func clearAuctionRange<X>(
+  public func clearRange<X>(
     asks : Iter.Iter<Order<X>>,
     bids : Iter.Iter<Order<X>>,
     less : (X, X) -> Bool,

--- a/test/clear-auction.test.mo
+++ b/test/clear-auction.test.mo
@@ -1,8 +1,10 @@
 import Prim "mo:prim";
 
-import { clearAuction; clearAuctionRange } "../src";
+import Clear "../src";
 
-type Order = (Float, Nat);
+type Order = Clear.Order<Float>;
+let clearAuction = Clear.clearAuctionFloat;
+let clearAuctionRange = Clear.clearAuctionRange;
 
 do {
   Prim.debugPrint("should fulfil many bids, use min price...");

--- a/test/clear-auction.test.mo
+++ b/test/clear-auction.test.mo
@@ -1,7 +1,6 @@
-import Iter "mo:base/Iter";
 import Prim "mo:prim";
 
-import { clearAuction } "../src";
+import { clearAuction; clearAuctionRange } "../src";
 
 type Order = (Float, Nat);
 
@@ -11,8 +10,9 @@ do {
     [(20, 100)], // asks ascending
     [(100, 20), (90, 20), (80, 20), (70, 20), (60, 20), (50, 20), (40, 20)] // bids descending
   );
-  let expect = (20.0, 100);
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  let expect = (20.0, 60.0, 100);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
 };
 
 do {
@@ -21,8 +21,9 @@ do {
     [(50, 100)], // asks ascending
     [(100, 60), (90, 60), (80, 60)] // bids descending
   );
-  let expect = (50.0, 100);
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  let expect = (50.0, 90.0, 100);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
 };
 
 do {
@@ -31,8 +32,9 @@ do {
     [(50, 100), (60, 100), (70, 100)], // asks ascending
     [(100, 100), (90, 100), (80, 100)] // bids descending
   );
-  let expect = (70.0, 300);
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  let expect = (70.0, 80.0, 300);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
 };
 
 do {
@@ -41,8 +43,9 @@ do {
     [(80, 100), (90, 100), (100, 100)], // asks ascending
     [(70, 100), (60, 100), (50, 100)] // bids descending
   );
-  let expect = (0.0, 0);
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  let expect = (0.0, 0.0, 0);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
 };
 
 do {
@@ -51,8 +54,9 @@ do {
     [(10, 10), (20, 10), (30, 10)], // asks ascending
     [(30, 10), (20, 10), (10, 10)], // bids descending
   );
-  let expect = (20.0, 20);
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  let expect = (20.0, 20.0, 20);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
 };
 
 do {
@@ -61,8 +65,9 @@ do {
     [(5, 10), (15, 10), (25, 10)], // asks ascending
     [(30, 10), (20, 10), (10, 10)], // bids descending
   );
-  let expect = (15.0, 20);
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  let expect = (15.0, 20.0, 20);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
 };
 
 do {
@@ -71,8 +76,9 @@ do {
     [(5, 10), (15, 10), (25, 10)], // asks ascending
     [(30, 15), (20, 10), (10, 10)], // bids descending
   );
-  let expect = (15.0, 20);
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  let expect = (15.0, 20.0, 20);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
 };
 
 do {
@@ -81,8 +87,9 @@ do {
     [(5, 10), (15, 10), (25, 10)], // asks ascending
     [(30, 20), (20, 10), (10, 10)], // bids descending
   );
-  let expect = (15.0, 20);
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  let expect = (15.0, 30.0, 20);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
 };
 
 do {
@@ -91,6 +98,7 @@ do {
     [(5, 10), (15, 10), (25, 10)], // asks ascending
     [(30, 25), (20, 10), (10, 10)], // bids descending
   );
-  let expect = (25.0, 25);
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  let expect = (25.0, 30.0, 25);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
 };

--- a/test/clear-auction.test.mo
+++ b/test/clear-auction.test.mo
@@ -2,21 +2,21 @@ import Float "mo:base/Float";
 import Iter "mo:base/Iter";
 import Prim "mo:prim";
 
-import Clear "../src";
+import Auction "../src";
 
-type Order = Clear.Order<Float>;
+type Order = Auction.Order<Float>;
 
 func clearAuction(
   asks : Iter.Iter<Order>,
   bids : Iter.Iter<Order>,
-) : ?Clear.priceResult<Float> {
-  Clear.clearAuction<Float>(asks, bids, Float.less);
+) : ?Auction.priceResult<Float> {
+  Auction.clearAuction<Float>(asks, bids, Float.less);
 };
 func clearAuctionRange(
   asks : Iter.Iter<Order>,
   bids : Iter.Iter<Order>,
-) : ?Clear.rangeResult<Float> {
-  Clear.clearAuctionRange<Float>(asks, bids, Float.less);
+) : ?Auction.rangeResult<Float> {
+  Auction.clearAuctionRange<Float>(asks, bids, Float.less);
 };
 
 do {

--- a/test/clear-auction.test.mo
+++ b/test/clear-auction.test.mo
@@ -3,6 +3,8 @@ import Prim "mo:prim";
 
 import { clearAuction } "../src";
 
+type Order = (Float, Nat);
+
 do {
   Prim.debugPrint("should fulfil many bids, use min price...");
   let asks = Iter.fromArray<(Float, Nat)>([
@@ -75,4 +77,50 @@ do {
   let (price, volume) = clearAuction(asks, bids);
   assert volume == 0;
   assert price == 0.0;
+};
+
+do {
+ Prim.debugPrint("Example 1"); 
+ let orders : ([Order], [Order]) = (
+  [(10, 10), (20, 10), (30, 10)], // asks ascending
+  [(30, 10), (20, 10), (10, 10)], // bids descending
+ );
+ let expect = (20.0, 20);
+ assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+};
+do {
+ Prim.debugPrint("Example 2"); 
+ let orders : ([Order], [Order]) = (
+  [(5, 10), (15, 10), (25, 10)], // asks ascending
+  [(30, 10), (20, 10), (10, 10)], // bids descending
+ );
+ let expect = (15.0, 20);
+ assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+};
+do {
+ Prim.debugPrint("Example 3"); 
+ let orders : ([Order], [Order]) = (
+  [(5, 10), (15, 10), (25, 10)], // asks ascending
+  [(30, 15), (20, 10), (10, 10)], // bids descending
+ );
+ let expect = (15.0, 20);
+ assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+};
+do {
+ Prim.debugPrint("Example 4"); 
+ let orders : ([Order], [Order]) = (
+  [(5, 10), (15, 10), (25, 10)], // asks ascending
+  [(30, 20), (20, 10), (10, 10)], // bids descending
+ );
+ let expect = (15.0, 20);
+ assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+};
+do {
+ Prim.debugPrint("Example 5"); 
+ let orders : ([Order], [Order]) = (
+  [(5, 10), (15, 10), (25, 10)], // asks ascending
+  [(30, 25), (20, 10), (10, 10)], // bids descending
+ );
+ let expect = (25.0, 25);
+ assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
 };

--- a/test/clear-auction.test.mo
+++ b/test/clear-auction.test.mo
@@ -102,3 +102,36 @@ do {
   assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
   assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
 };
+
+do {
+  Prim.debugPrint("Negative prices");
+  let orders : ([Order], [Order]) = (
+    [(-30, 10), (-20, 10), (-10, 10)], // asks ascending
+    [(-10, 10), (-20, 10), (-30, 10)], // bids descending
+  );
+  let expect = (-20.0, -20.0, 20);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+};
+
+do {
+  Prim.debugPrint("Infinite prices");
+  let orders : ([Order], [Order]) = (
+    [(-1/0, 10), (-20, 10), (1/0, 10)], // asks ascending
+    [(1/0, 10), (-20, 10), (-1/0, 10)], // bids descending
+  );
+  let expect = (-20.0, -20.0, 20);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+};
+
+do {
+  Prim.debugPrint("Zero volume");
+  let orders : ([Order], [Order]) = (
+    [(10, 0), (15, 0), (15, 10), (20, 0), (20, 10)], // asks ascending
+    [(25, 0), (20, 10), (15, 20)], // bids descending
+  );
+  let expect = (15.0, 20.0, 10);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+};

--- a/test/clear-auction.test.mo
+++ b/test/clear-auction.test.mo
@@ -1,10 +1,24 @@
+import Float "mo:base/Float";
+import Iter "mo:base/Iter";
 import Prim "mo:prim";
 
 import Clear "../src";
 
 type Order = Clear.Order<Float>;
-let clearAuction = Clear.clearAuctionFloat;
-let clearAuctionRange = Clear.clearAuctionRangeFloat;
+
+func clearAuction(
+  asks : Iter.Iter<Order>,
+  bids : Iter.Iter<Order>,
+) : ?Clear.priceResult<Float> {
+  Clear.clearAuction<Float>(asks, bids, Float.less);
+};
+func clearAuctionRange(
+  asks : Iter.Iter<Order>,
+  bids : Iter.Iter<Order>,
+) : ?Clear.rangeResult<Float> {
+  Clear.clearAuctionRange<Float>(asks, bids, Float.less);
+};
+
 
 do {
   Prim.debugPrint("should fulfil many bids, use min price...");
@@ -13,8 +27,11 @@ do {
     [(100, 20), (90, 20), (80, 20), (70, 20), (60, 20), (50, 20), (40, 20)] // bids descending
   );
   let expect = (20.0, 60.0, 100);
-  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
 };
 
 do {
@@ -24,8 +41,11 @@ do {
     [(100, 60), (90, 60), (80, 60)] // bids descending
   );
   let expect = (50.0, 90.0, 100);
-  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
 };
 
 do {
@@ -35,8 +55,11 @@ do {
     [(100, 100), (90, 100), (80, 100)] // bids descending
   );
   let expect = (70.0, 80.0, 300);
-  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
 };
 
 do {
@@ -45,9 +68,8 @@ do {
     [(80, 100), (90, 100), (100, 100)], // asks ascending
     [(70, 100), (60, 100), (50, 100)] // bids descending
   );
-  let expect = (0.0, 0.0, 0);
-  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == null;
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == null;
 };
 
 do {
@@ -57,8 +79,11 @@ do {
     [(30, 10), (20, 10), (10, 10)], // bids descending
   );
   let expect = (20.0, 20.0, 20);
-  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
 };
 
 do {
@@ -68,8 +93,11 @@ do {
     [(30, 10), (20, 10), (10, 10)], // bids descending
   );
   let expect = (15.0, 20.0, 20);
-  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
 };
 
 do {
@@ -79,8 +107,11 @@ do {
     [(30, 15), (20, 10), (10, 10)], // bids descending
   );
   let expect = (15.0, 20.0, 20);
-  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
 };
 
 do {
@@ -90,8 +121,11 @@ do {
     [(30, 20), (20, 10), (10, 10)], // bids descending
   );
   let expect = (15.0, 30.0, 20);
-  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
 };
 
 do {
@@ -101,8 +135,11 @@ do {
     [(30, 25), (20, 10), (10, 10)], // bids descending
   );
   let expect = (25.0, 30.0, 25);
-  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
 };
 
 do {
@@ -112,19 +149,25 @@ do {
     [(-10, 10), (-20, 10), (-30, 10)], // bids descending
   );
   let expect = (-20.0, -20.0, 20);
-  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
 };
 
 do {
   Prim.debugPrint("Infinite prices");
   let orders : ([Order], [Order]) = (
-    [(-1/0, 10), (-20, 10), (1/0, 10)], // asks ascending
-    [(1/0, 10), (-20, 10), (-1/0, 10)], // bids descending
+    [(-1 / 0, 10), (-20, 10), (1 / 0, 10)], // asks ascending
+    [(1 / 0, 10), (-20, 10), (-1 / 0, 10)], // bids descending
   );
   let expect = (-20.0, -20.0, 20);
-  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
 };
 
 do {
@@ -134,6 +177,23 @@ do {
     [(25, 0), (20, 10), (15, 20)], // bids descending
   );
   let expect = (15.0, 20.0, 10);
-  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == { range = (expect.0, expect.1); volume = expect.2};
-  assert clearAuction(orders.0.vals(), orders.1.vals()) == (expect.0, expect.2);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
+};
+
+do {
+  Prim.debugPrint("Zero volume could affect range");
+  let orders : ([Order], [Order]) = (
+    [(10, 10)], // asks ascending
+    [(30, 5), (25, 0)], // bids descending
+  );
+  let expect = (10.0, 30.0, 5);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
 };

--- a/test/clear-auction.test.mo
+++ b/test/clear-auction.test.mo
@@ -7,120 +7,90 @@ type Order = (Float, Nat);
 
 do {
   Prim.debugPrint("should fulfil many bids, use min price...");
-  let asks = Iter.fromArray<(Float, Nat)>([
-    (20.0, 10000)
-  ]);
-  let bids = Iter.fromArray<(Float, Nat)>([
-    (100.0, 2000),
-    (90.0, 2000),
-    (80.0, 2000),
-    (70.0, 2000),
-    (60.0, 2000),
-    // do not filfil: out of volume
-    (50.0, 2000),
-    (40.0, 2000),
-  ]);
-
-  let (price, volume) = clearAuction(asks, bids);
-  assert volume == 10000;
-  assert price == 20.0;
+  let orders : ([Order], [Order]) = (
+    [(20, 100)], // asks ascending
+    [(100, 20), (90, 20), (80, 20), (70, 20), (60, 20), (50, 20), (40, 20)] // bids descending
+  );
+  let expect = (20.0, 100);
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
 };
 
 do {
   Prim.debugPrint("should fulfil bids partially...");
-  let asks = Iter.fromArray<(Float, Nat)>([
-    (50.0, 10000)
-  ]);
-  let bids = Iter.fromArray<(Float, Nat)>([
-    (100.0, 6000),
-    (90.0, 6000),
-    (80.0, 6000),
-  ]);
-
-  let (price, volume) = clearAuction(asks, bids);
-  assert volume == 10000;
-  assert price == 50.0;
+  let orders : ([Order], [Order]) = (
+    [(50, 100)], // asks ascending
+    [(100, 60), (90, 60), (80, 60)] // bids descending
+  );
+  let expect = (50.0, 100);
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
 };
 
 do {
   Prim.debugPrint("should fulfil many bids/asks, use ask price...");
-  let asks = Iter.fromArray<(Float, Nat)>([
-    (50.0, 10000),
-    (60.0, 10000),
-    (70.0, 10000),
-  ]);
-  let bids = Iter.fromArray<(Float, Nat)>([
-    (100.0, 10000),
-    (90.0, 10000),
-    (80.0, 10000),
-  ]);
-
-  let (price, volume) = clearAuction(asks, bids);
-  assert volume == 30000;
-  assert price == 70.0;
+  let orders : ([Order], [Order]) = (
+    [(50, 100), (60, 100), (70, 100)], // asks ascending
+    [(100, 100), (90, 100), (80, 100)] // bids descending
+  );
+  let expect = (70.0, 300);
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
 };
-
 
 do {
   Prim.debugPrint("should not fulfil anything if price does not match...");
-  let asks = Iter.fromArray<(Float, Nat)>([
-    (80.0, 10000),
-    (90.0, 10000),
-    (100.0, 10000),
-  ]);
-  let bids = Iter.fromArray<(Float, Nat)>([
-    (70.0, 10000),
-    (60.0, 10000),
-    (50.0, 10000),
-  ]);
-
-  let (price, volume) = clearAuction(asks, bids);
-  assert volume == 0;
-  assert price == 0.0;
+  let orders : ([Order], [Order]) = (
+    [(80, 100), (90, 100), (100, 100)], // asks ascending
+    [(70, 100), (60, 100), (50, 100)] // bids descending
+  );
+  let expect = (0.0, 0);
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
 };
 
 do {
- Prim.debugPrint("Example 1"); 
- let orders : ([Order], [Order]) = (
-  [(10, 10), (20, 10), (30, 10)], // asks ascending
-  [(30, 10), (20, 10), (10, 10)], // bids descending
- );
- let expect = (20.0, 20);
- assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  Prim.debugPrint("Example 1");
+  let orders : ([Order], [Order]) = (
+    [(10, 10), (20, 10), (30, 10)], // asks ascending
+    [(30, 10), (20, 10), (10, 10)], // bids descending
+  );
+  let expect = (20.0, 20);
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
 };
+
 do {
- Prim.debugPrint("Example 2"); 
- let orders : ([Order], [Order]) = (
-  [(5, 10), (15, 10), (25, 10)], // asks ascending
-  [(30, 10), (20, 10), (10, 10)], // bids descending
- );
- let expect = (15.0, 20);
- assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  Prim.debugPrint("Example 2");
+  let orders : ([Order], [Order]) = (
+    [(5, 10), (15, 10), (25, 10)], // asks ascending
+    [(30, 10), (20, 10), (10, 10)], // bids descending
+  );
+  let expect = (15.0, 20);
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
 };
+
 do {
- Prim.debugPrint("Example 3"); 
- let orders : ([Order], [Order]) = (
-  [(5, 10), (15, 10), (25, 10)], // asks ascending
-  [(30, 15), (20, 10), (10, 10)], // bids descending
- );
- let expect = (15.0, 20);
- assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  Prim.debugPrint("Example 3");
+  let orders : ([Order], [Order]) = (
+    [(5, 10), (15, 10), (25, 10)], // asks ascending
+    [(30, 15), (20, 10), (10, 10)], // bids descending
+  );
+  let expect = (15.0, 20);
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
 };
+
 do {
- Prim.debugPrint("Example 4"); 
- let orders : ([Order], [Order]) = (
-  [(5, 10), (15, 10), (25, 10)], // asks ascending
-  [(30, 20), (20, 10), (10, 10)], // bids descending
- );
- let expect = (15.0, 20);
- assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  Prim.debugPrint("Example 4");
+  let orders : ([Order], [Order]) = (
+    [(5, 10), (15, 10), (25, 10)], // asks ascending
+    [(30, 20), (20, 10), (10, 10)], // bids descending
+  );
+  let expect = (15.0, 20);
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
 };
+
 do {
- Prim.debugPrint("Example 5"); 
- let orders : ([Order], [Order]) = (
-  [(5, 10), (15, 10), (25, 10)], // asks ascending
-  [(30, 25), (20, 10), (10, 10)], // bids descending
- );
- let expect = (25.0, 25);
- assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
+  Prim.debugPrint("Example 5");
+  let orders : ([Order], [Order]) = (
+    [(5, 10), (15, 10), (25, 10)], // asks ascending
+    [(30, 25), (20, 10), (10, 10)], // bids descending
+  );
+  let expect = (25.0, 25);
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == expect;
 };

--- a/test/clear-auction.test.mo
+++ b/test/clear-auction.test.mo
@@ -10,13 +10,13 @@ func clearAuction(
   asks : Iter.Iter<Order>,
   bids : Iter.Iter<Order>,
 ) : ?Auction.priceResult<Float> {
-  Auction.clearAuction<Float>(asks, bids, Float.less);
+  Auction.clear<Float>(asks, bids, Float.less);
 };
 func clearAuctionRange(
   asks : Iter.Iter<Order>,
   bids : Iter.Iter<Order>,
 ) : ?Auction.rangeResult<Float> {
-  Auction.clearAuctionRange<Float>(asks, bids, Float.less);
+  Auction.clearRange<Float>(asks, bids, Float.less);
 };
 
 do {

--- a/test/clear-auction.test.mo
+++ b/test/clear-auction.test.mo
@@ -19,7 +19,6 @@ func clearAuctionRange(
   Clear.clearAuctionRange<Float>(asks, bids, Float.less);
 };
 
-
 do {
   Prim.debugPrint("should fulfil many bids, use min price...");
   let orders : ([Order], [Order]) = (
@@ -171,12 +170,12 @@ do {
 };
 
 do {
-  Prim.debugPrint("Zero volume");
+  Prim.debugPrint("Zero volume ask could affect price");
   let orders : ([Order], [Order]) = (
-    [(10, 0), (15, 0), (15, 10), (20, 0), (20, 10)], // asks ascending
-    [(25, 0), (20, 10), (15, 20)], // bids descending
+    [(10, 5), (15, 0)], // asks ascending
+    [(20, 10)], // bids descending
   );
-  let expect = (15.0, 20.0, 10);
+  let expect = (10.0, 20.0, 5);
   assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
     range = (expect.0, expect.1);
     volume = expect.2;
@@ -185,7 +184,21 @@ do {
 };
 
 do {
-  Prim.debugPrint("Zero volume could affect range");
+  Prim.debugPrint("Zero volume ask could affect range");
+  let orders : ([Order], [Order]) = (
+    [(10, 10), (10, 0)], // asks ascending
+    [(30, 10), (25, 10)], // bids descending
+  );
+  let expect = (10.0, 30.0, 10);
+  assert clearAuctionRange(orders.0.vals(), orders.1.vals()) == ?{
+    range = (expect.0, expect.1);
+    volume = expect.2;
+  };
+  assert clearAuction(orders.0.vals(), orders.1.vals()) == ?(expect.0, expect.2);
+};
+
+do {
+  Prim.debugPrint("Zero volume bid could affect range");
   let orders : ([Order], [Order]) = (
     [(10, 10)], // asks ascending
     [(30, 5), (25, 0)], // bids descending

--- a/test/clear-auction.test.mo
+++ b/test/clear-auction.test.mo
@@ -4,7 +4,7 @@ import Clear "../src";
 
 type Order = Clear.Order<Float>;
 let clearAuction = Clear.clearAuctionFloat;
-let clearAuctionRange = Clear.clearAuctionRange;
+let clearAuctionRange = Clear.clearAuctionRangeFloat;
 
 do {
   Prim.debugPrint("should fulfil many bids, use min price...");


### PR DESCRIPTION
The former algorithm was using a single loop and sometimes stepped both sides (ask and bid) to the next order.

The new algorithm has two nested loops. It steps bids in an outer loop and asks in an inner loop. That makes some things easier to code. It is particularly beneficial if we are only interested in the lower end of the volume maximising range as the clearing price.

However, the algorithm is also capable of returning the full range with a small addition to it.